### PR TITLE
docs: add usage docs and runnable examples

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,121 @@
+# Advanced — recipes and gotchas
+
+## Guard an unknown language
+
+`from_pretrained` raises `KeyError` for a code it does not ship. Check against
+`MODELS` before loading, or catch it:
+
+```python
+from brill_postaggers import BrillPostagger
+
+def safe_tagger(lang: str):
+    code = lang.split("-")[0].lower()
+    if code not in BrillPostagger.MODELS:
+        return None
+    return BrillPostagger.from_pretrained(code)
+
+print(safe_tagger("pt-PT") is not None)   # True
+print(safe_tagger("ja"))                  # None
+```
+
+## Load each language once
+
+Constructing a tagger unpickles a model and calls `nltk.download('punkt_tab')`,
+so build one per language and keep it. A small cache avoids repeat work when you
+tag in several languages:
+
+```python
+from functools import lru_cache
+from brill_postaggers import BrillPostagger
+
+@lru_cache(maxsize=None)
+def tagger_for(lang: str) -> BrillPostagger:
+    return BrillPostagger.from_pretrained(lang)
+
+tagger_for("pt").tag("bom dia")
+tagger_for("pt").tag("boa noite")   # same instance, no reload
+```
+
+## Tag many sentences
+
+`tag()` works one sentence at a time. Wrap it for a batch:
+
+```python
+from brill_postaggers import BrillPostagger
+
+tagger = BrillPostagger.from_pretrained("en")
+sentences = ["I like cats.", "Dogs run fast."]
+tagged = [tagger.tag(s) for s in sentences]
+for s in tagged:
+    print(s)
+```
+
+## Pull out only the words of a given class
+
+The return is plain tuples, so filtering is ordinary Python. Extract the nouns,
+or the surface forms of any UD class:
+
+```python
+from brill_postaggers import BrillPostagger
+
+tagger = BrillPostagger.from_pretrained("pt")
+tagged = tagger.tag("o gato preto dorme no sofá")
+nouns = [w for w, tag in tagged if tag == "NOUN"]
+print(nouns)   # ['gato', 'sofá']
+```
+
+## Skip tokenization when you already have tokens
+
+`tag()` runs `nltk.word_tokenize` for you. If your pipeline already produced
+tokens, call the wrapped NLTK model directly via the `.tagger` attribute and
+keep your own tokenization:
+
+```python
+from brill_postaggers import BrillPostagger
+
+tagger = BrillPostagger.from_pretrained("en")
+tokens = ["state", "-", "of", "-", "the", "-", "art"]
+print(tagger.tagger.tag(tokens))
+```
+
+## Build a frequency profile
+
+Counting tags is a one-liner with `collections.Counter` — useful as a cheap
+syntactic fingerprint of a text:
+
+```python
+from collections import Counter
+from brill_postaggers import BrillPostagger
+
+tagger = BrillPostagger.from_pretrained("es")
+text = "el rápido zorro marrón salta sobre el perro perezoso"
+counts = Counter(tag for _, tag in tagger.tag(text))
+print(counts.most_common(3))
+```
+
+## Gotchas
+
+- The PyPI dist name is `brill_postagger` (singular); the import name is
+  `brill_postaggers` (plural).
+- The first construction needs network access for `nltk.download('punkt_tab')`.
+  After it caches to `~/nltk_data`, offline use works.
+- `from_pretrained` only splits on `-`, so `"pt_PT"` (underscore) is not
+  normalized and would `KeyError`. Pass the bare code or a `-` separated locale.
+- Tags follow the UD scheme, not the Penn Treebank scheme — expect `NOUN`, not
+  `NN`, and `PUNCT` for punctuation.
+- Accuracy reflects the source UD treebank for each language; out-of-domain or
+  heavily code-switched text degrades gracefully but is not the training target.
+
+## Where in the toolchain
+
+`brill_postaggers` is a leaf POS-tagging component of the TigreGotico NLP
+toolchain: a fast, dependency-light tagger you can drop into a larger pipeline
+when you need UD part-of-speech tags without pulling in a heavy model stack. It
+holds no entry points and is not an OVOS/OPM plugin — import it as a plain
+library.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first call
+- [api.md](api.md) — the full class and return-shape reference
+</content>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,112 @@
+# API reference
+
+Everything public lives in one module: `brill_postaggers`.
+
+```python
+from brill_postaggers import BrillPostagger
+```
+
+## `class BrillPostagger`
+
+A thin wrapper around a pickled NLTK Brill tagger.
+
+### `BrillPostagger.MODELS`
+
+Class attribute. A `dict[str, str]` mapping a language code to the model file
+stem that ships in the package:
+
+```python
+BrillPostagger.MODELS == {
+    "ca": "ca_ancora-ud-brill",
+    "da": "da_ddt-ud-brill",
+    "de": "de_gsd-ud-brill",
+    "en": "en_ewt-ud-brill",
+    "es": "es_ancora-ud-brill",
+    "eu": "eu_bdt-ud-brill",
+    "fr": "fr_gsd-ud-brill",
+    "gl": "gl_ctg-ud-brill",
+    "it": "it_vit-ud-brill",
+    "nl": "nl_alpino-ud-brill",
+    "pt": "pt_bosque-ud-brill",
+}
+```
+
+The stems encode the source treebank (for example `pt_bosque` is the Portuguese
+Bosque UD treebank). Use the keys to enumerate supported languages:
+
+```python
+for code in sorted(BrillPostagger.MODELS):
+    print(code)
+```
+
+### `BrillPostagger.from_pretrained(lang: str) -> BrillPostagger`
+
+Static method. The normal entry point. It:
+
+1. normalizes `lang` with `lang.split("-")[0].lower()`, so `"PT-BR"` -> `"pt"`,
+2. looks the code up in `MODELS` (raising `KeyError` for an unknown code),
+3. loads the bundled `<stem>.pkl` from the package directory,
+4. returns a ready `BrillPostagger`.
+
+```python
+tagger = BrillPostagger.from_pretrained("es")
+```
+
+The region split only handles a `-` separator, so `"pt-BR"` normalizes but
+`"pt_PT"` is passed through and would `KeyError`; pass the bare two-letter code
+when in doubt.
+
+### `BrillPostagger(model: str)`
+
+Constructor. `model` is the absolute path to a pickled NLTK tagger. Loading any
+instance calls `nltk.download('punkt_tab')` so the tokenizer is available. You
+rarely call this directly — prefer `from_pretrained` — but it lets you load a
+model you trained yourself:
+
+```python
+tagger = BrillPostagger("/path/to/my_lang-brill.pkl")
+```
+
+### `BrillPostagger.tag(sentence: str) -> list[tuple[str, str]]`
+
+Instance method. Word-tokenizes `sentence` with `nltk.word_tokenize`, then runs
+the Brill tagger over the tokens. Returns a list of `(token, tag)` tuples in
+order, with punctuation kept as its own token:
+
+```python
+tagger = BrillPostagger.from_pretrained("pt")
+tagger.tag("o gato dorme.")
+# [('o', 'DET'), ('gato', 'NOUN'), ('dorme', 'VERB'), ('.', 'PUNCT')]
+```
+
+Tags are [Universal Dependencies POS tags](https://universaldependencies.org/u/pos/):
+`ADJ`, `ADP`, `ADV`, `AUX`, `CCONJ`, `DET`, `INTJ`, `NOUN`, `NUM`, `PART`,
+`PRON`, `PROPN`, `PUNCT`, `SCONJ`, `SYM`, `VERB`, `X`.
+
+## Instance attributes
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `tagger` | NLTK Brill tagger | The unpickled model; exposes its own `.tag(tokens)` over pre-tokenized lists. |
+
+If you already have tokens, you can bypass `word_tokenize` and call the
+underlying model directly:
+
+```python
+tagger = BrillPostagger.from_pretrained("en")
+tagger.tagger.tag(["hello", "world"])
+# [('hello', 'INTJ'), ('world', 'NOUN')]
+```
+
+## Errors
+
+| Condition | Raised |
+| --- | --- |
+| Unknown language code in `from_pretrained` | `KeyError` |
+| Bad path in `BrillPostagger(model)` | `FileNotFoundError` |
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first call
+- [advanced.md](advanced.md) — guards, batching, reuse, tagset filtering
+</content>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart — zero to tagged
+
+`brill_postaggers` is part-of-speech tagging for 11 languages, shipped as
+pre-trained Brill models behind one small class. You give it a sentence, it
+gives you back `(word, tag)` tuples using the
+[Universal Dependencies](https://universaldependencies.org/u/pos/) tagset.
+
+## 1. Install
+
+```bash
+pip install brill_postagger        # PyPI dist name
+```
+
+The import name is plural: `brill_postaggers`. The only runtime dependency is
+`nltk`, and the 11 models travel inside the wheel as package data — no separate
+download of model files.
+
+## 2. The one thing to understand
+
+There is a single public class, `BrillPostagger`. You almost never construct it
+by path; you call `from_pretrained(lang)`, which loads the bundled model for that
+language code:
+
+```python
+from brill_postaggers import BrillPostagger
+
+tagger = BrillPostagger.from_pretrained("pt")
+print(tagger.tag("como está o tempo lá fora?"))
+# [('como', 'SCONJ'), ('está', 'AUX'), ('o', 'DET'), ('tempo', 'NOUN'),
+#  ('lá', 'ADV'), ('fora', 'ADV'), ('?', 'PUNCT')]
+```
+
+`tag()` word-tokenizes the sentence with NLTK first, then tags each token. The
+return is a list of `(token, tag)` tuples in sentence order, punctuation included.
+
+## 3. First call, end to end
+
+```python
+from brill_postaggers import BrillPostagger
+
+tagger = BrillPostagger.from_pretrained("en")
+for word, tag in tagger.tag("the quick brown fox jumps over the lazy dog"):
+    print(f"{word:<8} {tag}")
+```
+
+The first time any tagger is constructed, NLTK fetches its `punkt_tab`
+tokenizer tables (`nltk.download('punkt_tab')`). That needs network access once;
+afterwards it is cached under `~/nltk_data`.
+
+## 4. Pick a language
+
+Language codes are the keys of `BrillPostagger.MODELS`:
+
+```python
+from brill_postaggers import BrillPostagger
+
+print(sorted(BrillPostagger.MODELS))
+# ['ca', 'da', 'de', 'en', 'es', 'eu', 'fr', 'gl', 'it', 'nl', 'pt']
+```
+
+`from_pretrained` lowercases and strips a region suffix, so `"PT-BR"`, `"pt"`
+and `"pt_PT"` all resolve to the Portuguese model. An unknown code raises
+`KeyError` — see [advanced.md](advanced.md) for guarding that.
+
+## Where next
+
+- [api.md](api.md) — the class, every method/kwarg, and the return shape
+- [advanced.md](advanced.md) — tagsets, language guards, reuse, batching, gotchas
+</content>
+</invoke>

--- a/examples/01_first_tag.py
+++ b/examples/01_first_tag.py
@@ -1,0 +1,19 @@
+"""Example — load a Portuguese tagger and tag a sentence.
+
+Run::
+
+    python examples/01_first_tag.py
+"""
+
+from brill_postaggers import BrillPostagger
+
+
+def main() -> None:
+    tagger = BrillPostagger.from_pretrained("pt")
+    tagged = tagger.tag("como está o tempo lá fora?")
+    for word, tag in tagged:
+        print(f"{word:<8} {tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_languages.py
+++ b/examples/02_languages.py
@@ -1,0 +1,28 @@
+"""Example — enumerate supported languages and tag a sample in each.
+
+Run::
+
+    python examples/02_languages.py
+"""
+
+from brill_postaggers import BrillPostagger
+
+SAMPLES = {
+    "pt": "o gato preto dorme no sofá",
+    "es": "el rápido zorro marrón salta sobre el perro",
+    "fr": "le chat noir dort sur le canapé",
+    "en": "the quick brown fox jumps over the lazy dog",
+}
+
+
+def main() -> None:
+    print("supported codes:", sorted(BrillPostagger.MODELS))
+    for lang, text in SAMPLES.items():
+        tagger = BrillPostagger.from_pretrained(lang)
+        tagged = tagger.tag(text)
+        print(f"\n[{lang}] {text}")
+        print(" ", tagged)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_locale_normalization.py
+++ b/examples/03_locale_normalization.py
@@ -1,0 +1,20 @@
+"""Example — region-suffixed locales resolve to the base language model.
+
+Run::
+
+    python examples/03_locale_normalization.py
+"""
+
+from brill_postaggers import BrillPostagger
+
+
+def main() -> None:
+    text = "bom dia, como vai você?"
+    for locale in ("pt", "PT", "pt-BR", "PT-PT"):
+        tagger = BrillPostagger.from_pretrained(locale)
+        tagged = tagger.tag(text)
+        print(f"{locale:<6} -> {tagged}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_filter_by_class.py
+++ b/examples/04_filter_by_class.py
@@ -1,0 +1,27 @@
+"""Example — filter tagged tokens by Universal Dependencies POS class.
+
+Run::
+
+    python examples/04_filter_by_class.py
+"""
+
+from brill_postaggers import BrillPostagger
+
+
+def main() -> None:
+    tagger = BrillPostagger.from_pretrained("pt")
+    text = "o velho navegador português descobriu novas terras"
+    tagged = tagger.tag(text)
+
+    nouns = [w for w, tag in tagged if tag == "NOUN"]
+    adjectives = [w for w, tag in tagged if tag == "ADJ"]
+    verbs = [w for w, tag in tagged if tag == "VERB"]
+
+    print("sentence  :", text)
+    print("nouns     :", nouns)
+    print("adjectives:", adjectives)
+    print("verbs     :", verbs)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_tag_profile.py
+++ b/examples/05_tag_profile.py
@@ -1,0 +1,31 @@
+"""Example — build a POS-tag frequency profile of a paragraph.
+
+Run::
+
+    python examples/05_tag_profile.py
+"""
+
+from collections import Counter
+
+from brill_postaggers import BrillPostagger
+
+
+def main() -> None:
+    paragraph = (
+        "Os antigos navegadores partiram do porto ao amanhecer. "
+        "O vento forte empurrava as velas brancas para sul. "
+        "Depois de muitos dias no mar, avistaram finalmente a costa."
+    )
+    tagger = BrillPostagger.from_pretrained("pt")
+
+    counts: Counter = Counter()
+    for sentence in paragraph.split(". "):
+        counts.update(tag for _, tag in tagger.tag(sentence))
+
+    print("tag profile (most common):")
+    for tag, n in counts.most_common():
+        print(f"  {tag:<6} {n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_pretokenized.py
+++ b/examples/06_pretokenized.py
@@ -1,0 +1,23 @@
+"""Example — tag your own tokens, bypassing the built-in tokenizer.
+
+Run::
+
+    python examples/06_pretokenized.py
+"""
+
+from brill_postaggers import BrillPostagger
+
+
+def main() -> None:
+    tagger = BrillPostagger.from_pretrained("en")
+
+    # Already-tokenized input: feed the wrapped NLTK model directly.
+    tokens = ["state", "-", "of", "-", "the", "-", "art", "design"]
+    print("pre-tokenized:", tagger.tagger.tag(tokens))
+
+    # Compare with the convenience path that tokenizes for you.
+    print("via tag()   :", tagger.tag("state-of-the-art design"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a `docs/` directory and an `examples/` directory for the library.

## docs/
- `quickstart.md` — install, the `from_pretrained` core idea, and a first tag call.
- `api.md` — `BrillPostagger` class, `MODELS`, `from_pretrained`, `tag`, return shape, UD tagset, and errors.
- `advanced.md` — language guards, per-language caching, batching, class filtering, pre-tokenized input, tag profiles, and gotchas.

## examples/
Six numbered runnable scripts using only the public API and stdlib, with inline Portuguese/Spanish/French/English samples:
- `01_first_tag.py` — load a Portuguese tagger and tag a sentence.
- `02_languages.py` — enumerate supported languages and tag a sample in each.
- `03_locale_normalization.py` — region-suffixed locales resolve to the base model.
- `04_filter_by_class.py` — filter tokens by UD POS class.
- `05_tag_profile.py` — POS-tag frequency profile of a paragraph.
- `06_pretokenized.py` — tag your own tokens via the wrapped model.

All six examples run to exit 0 against the bundled models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation including quickstart guide, API reference, and advanced usage patterns
  * Covers installation, basic tagging, language selection, locale handling, and error conditions

* **New Features**
  * Added six example scripts demonstrating common use cases: basic tagging, multi-language support, filtering by part-of-speech class, tag frequency analysis, and pre-tokenized input handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/brill_postaggers/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->