### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Brill Postagger
 
-A Python package that uses the Brill Tagging algorithm for part-of-speech tagging, available for several languages. It utilizes the NLTK library for tokenization and tagging.
+`brill_postaggers` is a Python package for part-of-speech tagging. It uses the
+Brill Tagging algorithm and ships pre-trained models for several languages. It
+uses the NLTK library for tokenization and tagging.
 
-Models have been trained with [UniversalDependencies](https://github.com/UniversalDependencies) datasets
+The models are trained with [UniversalDependencies](https://github.com/UniversalDependencies) datasets.
 
 ## Installation
 
-To install the package, you can use pip:
+Install the package with pip:
 
 ```bash
 pip install brill_postagger
@@ -14,12 +16,13 @@ pip install brill_postagger
 
 ## Usage
 
-To use the Brill Postagger, first download the corresponding pre-trained model, then use it to tag sentences in various languages.
+To use the Brill Postagger, load the pre-trained model for a language, then
+use it to tag a sentence.
 
 Example usage:
 
 ```python
-from brill_postagger import BrillPostagger
+from brill_postaggers import BrillPostagger
 
 # Initialize the tagger for Portuguese (pt)
 tagger = BrillPostagger.from_pretrained("pt")
@@ -29,9 +32,13 @@ result = tagger.tag("como está o tempo lá fora?")
 print(result)
 ```
 
+See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough,
+[docs/api.md](docs/api.md) for the class reference, and
+[docs/advanced.md](docs/advanced.md) for recipes and gotchas.
+
 ### Supported Languages
 
-The following languages are supported, each corresponding to a pre-trained model:
+Each language below has its own pre-trained model:
 
 - Catalan (`ca`)
 - Danish (`da`)
@@ -45,10 +52,17 @@ The following languages are supported, each corresponding to a pre-trained model
 - Dutch (`nl`)
 - Portuguese (`pt`)
 
+### Related projects
+
+- [TigreGotico/crf_query_xtract](https://github.com/TigreGotico/crf_query_xtract), a CRF-based query-extraction tagger in the same TigreGotico NLP toolchain.
+- [TigreGotico/tugatagger](https://github.com/TigreGotico/tugatagger), a Portuguese POS tagger.
+
 ### Contributing
 
-If you'd like to contribute to the project, please feel free to submit issues or pull requests. Contributions are always welcome!
+If you would like to contribute to the project, submit issues or pull
+requests. Contributions are welcome.
 
 ### License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project uses the MIT License. See the [LICENSE](LICENSE) file for
+details.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,9 +1,9 @@
-# Advanced — recipes and gotchas
+# Advanced: recipes and gotchas
 
 ## Guard an unknown language
 
 `from_pretrained` raises `KeyError` for a code it does not ship. Check against
-`MODELS` before loading, or catch it:
+`MODELS` before loading, or catch the error:
 
 ```python
 from brill_postaggers import BrillPostagger
@@ -20,9 +20,9 @@ print(safe_tagger("ja"))                  # None
 
 ## Load each language once
 
-Constructing a tagger unpickles a model and calls `nltk.download('punkt_tab')`,
-so build one per language and keep it. A small cache avoids repeat work when you
-tag in several languages:
+Constructing a tagger unpickles a model and calls `nltk.download('punkt_tab')`.
+Build one tagger per language and keep it. A small cache avoids repeat work
+when you tag text in several languages:
 
 ```python
 from functools import lru_cache
@@ -38,7 +38,7 @@ tagger_for("pt").tag("boa noite")   # same instance, no reload
 
 ## Tag many sentences
 
-`tag()` works one sentence at a time. Wrap it for a batch:
+`tag()` works one sentence at a time. Wrap it to process a batch:
 
 ```python
 from brill_postaggers import BrillPostagger
@@ -52,8 +52,8 @@ for s in tagged:
 
 ## Pull out only the words of a given class
 
-The return is plain tuples, so filtering is ordinary Python. Extract the nouns,
-or the surface forms of any UD class:
+The return value is plain tuples, so filtering is ordinary Python. Extract
+the nouns, or the surface forms of any UD class:
 
 ```python
 from brill_postaggers import BrillPostagger
@@ -67,8 +67,8 @@ print(nouns)   # ['gato', 'sofá']
 ## Skip tokenization when you already have tokens
 
 `tag()` runs `nltk.word_tokenize` for you. If your pipeline already produced
-tokens, call the wrapped NLTK model directly via the `.tagger` attribute and
-keep your own tokenization:
+tokens, call the wrapped NLTK model directly through the `.tagger` attribute
+and keep your own tokenization:
 
 ```python
 from brill_postaggers import BrillPostagger
@@ -80,7 +80,7 @@ print(tagger.tagger.tag(tokens))
 
 ## Build a frequency profile
 
-Counting tags is a one-liner with `collections.Counter` — useful as a cheap
+Counting tags is a one-liner with `collections.Counter`. This gives a cheap
 syntactic fingerprint of a text:
 
 ```python
@@ -95,27 +95,25 @@ print(counts.most_common(3))
 
 ## Gotchas
 
-- The PyPI dist name is `brill_postagger` (singular); the import name is
+- The PyPI dist name is `brill_postagger` (singular). The import name is
   `brill_postaggers` (plural).
 - The first construction needs network access for `nltk.download('punkt_tab')`.
   After it caches to `~/nltk_data`, offline use works.
 - `from_pretrained` only splits on `-`, so `"pt_PT"` (underscore) is not
-  normalized and would `KeyError`. Pass the bare code or a `-` separated locale.
-- Tags follow the UD scheme, not the Penn Treebank scheme — expect `NOUN`, not
-  `NN`, and `PUNCT` for punctuation.
-- Accuracy reflects the source UD treebank for each language; out-of-domain or
-  heavily code-switched text degrades gracefully but is not the training target.
+  normalized and raises `KeyError`. Pass the bare code or a `-` separated locale.
+- Tags follow the UD scheme, not the Penn Treebank scheme. Expect `NOUN`,
+  not `NN`, and `PUNCT` for punctuation.
+- Accuracy reflects the source UD treebank for each language. Out-of-domain
+  or heavily code-switched text degrades gracefully but is not the training
+  target.
 
 ## Where in the toolchain
 
 `brill_postaggers` is a leaf POS-tagging component of the TigreGotico NLP
-toolchain: a fast, dependency-light tagger you can drop into a larger pipeline
-when you need UD part-of-speech tags without pulling in a heavy model stack. It
-holds no entry points and is not an OVOS/OPM plugin — import it as a plain
+toolchain: a dependency-light tagger you can drop into a larger pipeline when
+you need UD part-of-speech tags without pulling in a heavy model stack. It
+holds no entry points and is not an OVOS/OPM plugin. Import it as a plain
 library.
 
-## Where next
-
-- [quickstart.md](quickstart.md) — install and first call
-- [api.md](api.md) — the full class and return-shape reference
-</content>
+---
+[← API reference](api.md) · [Home](../README.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,8 +12,8 @@ A thin wrapper around a pickled NLTK Brill tagger.
 
 ### `BrillPostagger.MODELS`
 
-Class attribute. A `dict[str, str]` mapping a language code to the model file
-stem that ships in the package:
+Class attribute. A `dict[str, str]` that maps a language code to the model
+file stem shipped in the package:
 
 ```python
 BrillPostagger.MODELS == {
@@ -31,8 +31,8 @@ BrillPostagger.MODELS == {
 }
 ```
 
-The stems encode the source treebank (for example `pt_bosque` is the Portuguese
-Bosque UD treebank). Use the keys to enumerate supported languages:
+The stems encode the source treebank. For example, `pt_bosque` is the
+Portuguese Bosque UD treebank. Use the keys to list the supported languages:
 
 ```python
 for code in sorted(BrillPostagger.MODELS):
@@ -41,27 +41,27 @@ for code in sorted(BrillPostagger.MODELS):
 
 ### `BrillPostagger.from_pretrained(lang: str) -> BrillPostagger`
 
-Static method. The normal entry point. It:
+Static method. The normal entry point. It does the following:
 
-1. normalizes `lang` with `lang.split("-")[0].lower()`, so `"PT-BR"` -> `"pt"`,
-2. looks the code up in `MODELS` (raising `KeyError` for an unknown code),
-3. loads the bundled `<stem>.pkl` from the package directory,
-4. returns a ready `BrillPostagger`.
+1. Normalizes `lang` with `lang.split("-")[0].lower()`, so `"PT-BR"` becomes `"pt"`.
+2. Looks the code up in `MODELS`, raising `KeyError` for an unknown code.
+3. Loads the bundled `<stem>.pkl` from the package directory.
+4. Returns a ready `BrillPostagger`.
 
 ```python
 tagger = BrillPostagger.from_pretrained("es")
 ```
 
-The region split only handles a `-` separator, so `"pt-BR"` normalizes but
-`"pt_PT"` is passed through and would `KeyError`; pass the bare two-letter code
-when in doubt.
+The region split only handles a `-` separator. `"pt-BR"` normalizes, but
+`"pt_PT"` passes through unchanged and raises `KeyError`. Pass the bare
+two-letter code when in doubt.
 
 ### `BrillPostagger(model: str)`
 
-Constructor. `model` is the absolute path to a pickled NLTK tagger. Loading any
-instance calls `nltk.download('punkt_tab')` so the tokenizer is available. You
-rarely call this directly — prefer `from_pretrained` — but it lets you load a
-model you trained yourself:
+Constructor. `model` is the absolute path to a pickled NLTK tagger. Loading
+any instance calls `nltk.download('punkt_tab')` so the tokenizer is
+available. You rarely call this directly (prefer `from_pretrained`), but it
+lets you load a model you trained yourself:
 
 ```python
 tagger = BrillPostagger("/path/to/my_lang-brill.pkl")
@@ -69,9 +69,9 @@ tagger = BrillPostagger("/path/to/my_lang-brill.pkl")
 
 ### `BrillPostagger.tag(sentence: str) -> list[tuple[str, str]]`
 
-Instance method. Word-tokenizes `sentence` with `nltk.word_tokenize`, then runs
-the Brill tagger over the tokens. Returns a list of `(token, tag)` tuples in
-order, with punctuation kept as its own token:
+Instance method. Word-tokenizes `sentence` with `nltk.word_tokenize`, then
+runs the Brill tagger over the tokens. Returns a list of `(token, tag)`
+tuples in order, with punctuation kept as its own token:
 
 ```python
 tagger = BrillPostagger.from_pretrained("pt")
@@ -87,10 +87,10 @@ Tags are [Universal Dependencies POS tags](https://universaldependencies.org/u/p
 
 | Attribute | Type | Notes |
 | --- | --- | --- |
-| `tagger` | NLTK Brill tagger | The unpickled model; exposes its own `.tag(tokens)` over pre-tokenized lists. |
+| `tagger` | NLTK Brill tagger | The unpickled model. It exposes its own `.tag(tokens)` over pre-tokenized lists. |
 
 If you already have tokens, you can bypass `word_tokenize` and call the
-underlying model directly:
+wrapped NLTK model directly through the `.tagger` attribute:
 
 ```python
 tagger = BrillPostagger.from_pretrained("en")
@@ -105,8 +105,5 @@ tagger.tagger.tag(["hello", "world"])
 | Unknown language code in `from_pretrained` | `KeyError` |
 | Bad path in `BrillPostagger(model)` | `FileNotFoundError` |
 
-## Where next
-
-- [quickstart.md](quickstart.md) — install and first call
-- [advanced.md](advanced.md) — guards, batching, reuse, tagset filtering
-</content>
+---
+[← Quickstart](quickstart.md) · [Home](../README.md) · [Advanced →](advanced.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,8 @@
-# Quickstart — zero to tagged
+# Quickstart: zero to tagged
 
-`brill_postaggers` is part-of-speech tagging for 11 languages, shipped as
-pre-trained Brill models behind one small class. You give it a sentence, it
-gives you back `(word, tag)` tuples using the
+`brill_postaggers` does part-of-speech tagging for 11 languages, using
+pre-trained Brill models behind one small class. You give it a sentence, and
+it gives you back `(word, tag)` tuples, using the
 [Universal Dependencies](https://universaldependencies.org/u/pos/) tagset.
 
 ## 1. Install
@@ -12,14 +12,14 @@ pip install brill_postagger        # PyPI dist name
 ```
 
 The import name is plural: `brill_postaggers`. The only runtime dependency is
-`nltk`, and the 11 models travel inside the wheel as package data — no separate
-download of model files.
+`nltk`. The 11 models travel inside the wheel as package data, so you do not
+need a separate download of model files.
 
 ## 2. The one thing to understand
 
-There is a single public class, `BrillPostagger`. You almost never construct it
-by path; you call `from_pretrained(lang)`, which loads the bundled model for that
-language code:
+There is a single public class, `BrillPostagger`. You almost never construct
+it by path. Instead, call `from_pretrained(lang)`, which loads the bundled
+model for that language code:
 
 ```python
 from brill_postaggers import BrillPostagger
@@ -31,7 +31,8 @@ print(tagger.tag("como está o tempo lá fora?"))
 ```
 
 `tag()` word-tokenizes the sentence with NLTK first, then tags each token. The
-return is a list of `(token, tag)` tuples in sentence order, punctuation included.
+return value is a list of `(token, tag)` tuples in sentence order, with
+punctuation included.
 
 ## 3. First call, end to end
 
@@ -43,9 +44,9 @@ for word, tag in tagger.tag("the quick brown fox jumps over the lazy dog"):
     print(f"{word:<8} {tag}")
 ```
 
-The first time any tagger is constructed, NLTK fetches its `punkt_tab`
-tokenizer tables (`nltk.download('punkt_tab')`). That needs network access once;
-afterwards it is cached under `~/nltk_data`.
+The first time you construct any tagger, NLTK fetches its `punkt_tab`
+tokenizer tables (`nltk.download('punkt_tab')`). This needs network access
+once. After that, it is cached under `~/nltk_data`.
 
 ## 4. Pick a language
 
@@ -58,13 +59,10 @@ print(sorted(BrillPostagger.MODELS))
 # ['ca', 'da', 'de', 'en', 'es', 'eu', 'fr', 'gl', 'it', 'nl', 'pt']
 ```
 
-`from_pretrained` lowercases and strips a region suffix, so `"PT-BR"`, `"pt"`
-and `"pt_PT"` all resolve to the Portuguese model. An unknown code raises
-`KeyError` — see [advanced.md](advanced.md) for guarding that.
+`from_pretrained` lowercases the code and strips a region suffix after a
+hyphen, so `"PT-BR"` and `"pt"` both resolve to the Portuguese model.
+`"pt_PT"` (underscore) is not split and raises `KeyError`. See
+[advanced.md](advanced.md) for how to guard against that.
 
-## Where next
-
-- [api.md](api.md) — the class, every method/kwarg, and the return shape
-- [advanced.md](advanced.md) — tagsets, language guards, reuse, batching, gotchas
-</content>
-</invoke>
+---
+[Home](../README.md) · [API reference →](api.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md for clarity, using Simplified Technical English. Adds relative-link navigation footers across the docs set, keeps every existing fact, and fixes two inconsistencies in the docs (a wrong import name in the README's example, and a wrong claim about `pt_PT` normalizing) against the actual source.

Rewritten with Claude Fable 5 using the ste-writing skill; linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation, usage, language support, and contribution guidance.
  * Expanded Quickstart, API, and Advanced documentation with clearer examples and navigation.
  * Documented model loading, language-code handling, tokenization setup, caching, and tagging behavior.
  * Refreshed related-project and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->